### PR TITLE
fix: raid cursor binding issue

### DIFF
--- a/ConsolePort/Cursors/UnitFrames.lua
+++ b/ConsolePort/Cursors/UnitFrames.lua
@@ -359,6 +359,20 @@ function ConsolePort:LoadRaidCursor()
 	Cursor:SetAttribute('modifier', db.Settings.raidCursorModifier or '')
 end
 
+local function RestoreRaidCursorBindings()
+	if not InCombatLockdown() then
+		local isEnabled = Cursor:GetAttribute('enabled')
+		if isEnabled then
+			local Pager = ConsolePort:GetPager()
+			if Pager then
+				Pager:RunFor(Cursor, Cursor:GetAttribute('ToggleCursor'))
+			end
+		end
+	end
+end
+
+ConsolePort:RegisterCallback('OnNewBindings', RestoreRaidCursorBindings)
+
 --------------------------------------------------------------
 Cursor.ScaleUp = Cursor.Group.ScaleUp
 Cursor.ScaleDown = Cursor.Group.ScaleDown


### PR DESCRIPTION
Fixes a bug I noticed in the raid cursor. Basically what's happening is every time combat state toggles the cursor stays up but the bindings seem to get nuked.

#### Repro
1. Enable raid cursor
2. Become in combat
3. Use D-Pad to move cursor
4. Cursor is stuck and bindings go through to the action bar instead