### PR TITLE
Fix binding reload loop causing stutters

### DIFF
--- a/ConsolePort/Config/Binds.lua
+++ b/ConsolePort/Config/Binds.lua
@@ -436,53 +436,115 @@ end
 ---------------------------------------------------------------
 -- Binds: Create and handle addon bindings
 ---------------------------------------------------------------
-local function SetTempBinding(self, modifier, original, override)
+-- Applying overrides fires UPDATE_BINDINGS, which queues another
+-- LoadBindingSet, whose OnNewBindings callbacks apply overrides of their
+-- own, firing UPDATE_BINDINGS again. To break that cycle, the overrides
+-- are collected into a plan first and only flushed to the handler when
+-- they differ from what is already applied. A redundant reload then
+-- writes nothing, emits no events and skips the callback chain.
+local appliedOverrides = {}
+
+local function PlanTempBinding(plan, modifier, original, override)
 	if original and override then
 		local key1, key2 = GetBindingKey(original) or config.mouseBindings[original]
-		if key1 then SetOverrideBinding(self, false, modifier..key1, override) end
-		if key2 then SetOverrideBinding(self, false, modifier..key2, override) end
+		if key1 then plan[modifier..key1] = override end
+		if key2 then plan[modifier..key2] = override end
 	end
 end
 
-local function SetMouseBindings(self, handler, bindingSet)
+local function PlanMouseBindings(plan, bindingSet)
 	for stick, button in pairs(config.mouseBindings) do
 		if bindingSet[stick] and bindingSet[stick][""] then
 			for modifier in ConsolePort:GetModifiers() do
 				if modifier ~= "" then
-					SetOverrideBinding(handler, false, modifier..button, config.mouseDefault[button])
+					plan[modifier..button] = config.mouseDefault[button]
 				end
 			end
 		end
 	end
 end
 
+local function PlansMatch(a, b)
+	for key, override in pairs(a) do
+		if b[key] ~= override then return false end
+	end
+	for key, override in pairs(b) do
+		if a[key] ~= override then return false end
+	end
+	return true
+end
+
 function ConsolePort:LoadBindingSet(newBindingSet, fireCallback)
 	if(InCombatLockdown()) then return end
-	
+
 	local calibration = db('calibration')
 	if calibration then
 		for binding, key in pairs(calibration) do
-			SetBinding(key, binding)
+			-- SetBinding fires UPDATE_BINDINGS, so only write on mismatch.
+			-- Reading the live binding keeps this self-healing if the key
+			-- is reassigned elsewhere.
+			if GetBindingAction(key) ~= binding then
+				SetBinding(key, binding)
+			end
 		end
 	end
 	local bindingSet = newBindingSet or db.Bindings or {}
 	local handler = ConsolePortButtonHandler
-	ClearOverrideBindings(handler)
+
+	local plan = {}
 	if not db('disableStickMouse') then
-		SetMouseBindings(self, handler, bindingSet)
+		PlanMouseBindings(plan, bindingSet)
 	end
 	for name, key in pairs(bindingSet) do
 		local baseBinding = (not name:match('CP_T_.3')) and key['']
 		for modifier in self:GetModifiers() do
 			local modBinding = key[modifier]
-			SetTempBinding(handler, modifier, name, modBinding or baseBinding)
+			PlanTempBinding(plan, modifier, name, modBinding or baseBinding)
 		end
 	end
+
+	self:RemoveUpdateSnippet(self.LoadBindingSet)
+
+	if PlansMatch(plan, appliedOverrides) then
+		return bindingSet
+	end
+
+	ClearOverrideBindings(handler)
+	for key, override in pairs(plan) do
+		SetOverrideBinding(handler, false, key, override)
+	end
+	-- Store before dispatching, so any reload triggered from within the
+	-- callback chain sees the plan as already applied and bails out.
+	appliedOverrides = plan
+
 	if fireCallback then
 		self:OnNewBindings(bindingSet)
 	end
-	self:RemoveUpdateSnippet(self.LoadBindingSet)
 	return bindingSet
+end
+
+-- Forget which overrides are applied, so the next reload writes the full
+-- set again. Cheap insurance against the cache going stale: if anything
+-- ever wipes the handler's overrides behind our back, a stale cache would
+-- suppress the rebuild and leave the controller unbound.
+function ConsolePort:InvalidateBindingCache()
+	appliedOverrides = {}
+end
+
+do -- Entering the world is the one point where override state is uncertain.
+	-- Rebuild right away rather than waiting for the next binding event to
+	-- discover the empty cache, so the cost lands on the loading screen
+	-- instead of ambushing whatever happens first after it.
+	local guard = CreateFrame('Frame')
+	guard:RegisterEvent('PLAYER_ENTERING_WORLD')
+	guard:SetScript('OnEvent', function()
+		ConsolePort:InvalidateBindingCache()
+		if db.Bindings then
+			-- Queued rather than called directly, so it retries harmlessly
+			-- if the zone-in lands in combat, when binding writes are blocked.
+			ConsolePort:AddUpdateSnippet(ConsolePort.LoadBindingSet, db.Bindings, true)
+		end
+	end)
 end
 
 function ConsolePort:OnNewBindings(bindings) return db.Bindings end

--- a/ConsolePort/Core/Callback.lua
+++ b/ConsolePort/Core/Callback.lua
@@ -10,11 +10,14 @@ local interval, time, scripts = 0.1, 0, {}
 
 local function OnUpdate(self, elapsed)
 	time = time + elapsed
-	while time > interval do
-		for snippet, snippetData in pairs(scripts) do
-			snippet(self, unpack(snippetData))
-		end
-		time = time - interval
+	if time < interval then return end
+	-- Drop any backlog instead of catching up on it. These snippets poll
+	-- until their work becomes possible, so running them more than once
+	-- per frame achieves nothing -- and after a stall the catch-up would
+	-- run them once per skipped interval, turning one hitch into several.
+	time = 0
+	for snippet, snippetData in pairs(scripts) do
+		snippet(self, unpack(snippetData))
 	end
 end
 


### PR DESCRIPTION
`LoadBindingSet` was applying the full override binding layer on every `UPDATE_BINDINGS` event which is a binding write, both directly via `SetOverrideBinding` and again through the `OnNewBindings` callbacks. Profiling a mob pull measured a hitch of 307.8 ms in `LoadBindingSet`, 295.1 ms of that in the `OnNewBindings` chain.

With this change, we now collect the desired overrides into a plan and compare it against what was last applied. If nothing changes, we write nothing, emit no events and skip the callback chain, which terminates the loop. Similarly, a calibration pass only calls `SetBinding` on a mismatch, so it self-heals still.

Note: I have only tested this on my own personal hardware (Steam Deck) and can only confirm that this resolved the issue on my end. I have not end-to-end tested this, so please keep that in mind if/when approving :)